### PR TITLE
Rename MnemonicKit target

### DIFF
--- a/MnemonicKit.xcodeproj/project.pbxproj
+++ b/MnemonicKit.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 
 /* Begin PBXFileReference section */
 		03282044CA56B90979A64A9D /* Pods-MnemonicKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MnemonicKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MnemonicKit/Pods-MnemonicKit.debug.xcconfig"; sourceTree = "<group>"; };
-		778602AB2186370E0036843F /* MnemonicKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MnemonicKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		778602AB2186370E0036843F /* MnemonicKitExampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MnemonicKitExampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		778602AE2186370E0036843F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		778602B02186370E0036843F /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		778602B32186370E0036843F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -101,7 +101,7 @@
 		778602AC2186370E0036843F /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				778602AB2186370E0036843F /* MnemonicKit.app */,
+				778602AB2186370E0036843F /* MnemonicKitExampleApp.app */,
 				778602D421863BDD0036843F /* MnemonicKitTests.xctest */,
 			);
 			name = Products;
@@ -173,9 +173,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		778602AA2186370E0036843F /* MnemonicKit */ = {
+		778602AA2186370E0036843F /* MnemonicKitExampleApp */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 778602BD2186370F0036843F /* Build configuration list for PBXNativeTarget "MnemonicKit" */;
+			buildConfigurationList = 778602BD2186370F0036843F /* Build configuration list for PBXNativeTarget "MnemonicKitExampleApp" */;
 			buildPhases = (
 				C79E5827B2A830B6E069BB27 /* [CP] Check Pods Manifest.lock */,
 				778602A72186370E0036843F /* Sources */,
@@ -188,9 +188,9 @@
 			);
 			dependencies = (
 			);
-			name = MnemonicKit;
+			name = MnemonicKitExampleApp;
 			productName = MnemonicKit;
-			productReference = 778602AB2186370E0036843F /* MnemonicKit.app */;
+			productReference = 778602AB2186370E0036843F /* MnemonicKitExampleApp.app */;
 			productType = "com.apple.product-type.application";
 		};
 		778602D321863BDD0036843F /* MnemonicKitTests */ = {
@@ -247,7 +247,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				778602AA2186370E0036843F /* MnemonicKit */,
+				778602AA2186370E0036843F /* MnemonicKitExampleApp */,
 				778602D321863BDD0036843F /* MnemonicKitTests */,
 			);
 		};
@@ -378,7 +378,7 @@
 /* Begin PBXTargetDependency section */
 		778602DA21863BDD0036843F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 778602AA2186370E0036843F /* MnemonicKit */;
+			target = 778602AA2186370E0036843F /* MnemonicKitExampleApp */;
 			targetProxy = 778602D921863BDD0036843F /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -531,7 +531,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.MnemonicKit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.MnemonicKitExampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -550,7 +550,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.MnemonicKit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.MnemonicKitExampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -611,7 +611,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		778602BD2186370F0036843F /* Build configuration list for PBXNativeTarget "MnemonicKit" */ = {
+		778602BD2186370F0036843F /* Build configuration list for PBXNativeTarget "MnemonicKitExampleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				778602BE2186370F0036843F /* Debug */,

--- a/MnemonicKit.xcodeproj/project.pbxproj
+++ b/MnemonicKit.xcodeproj/project.pbxproj
@@ -574,7 +574,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MnemonicKit.app/MnemonicKit";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MnemonicKitExampleApp.app/MnemonicKitExampleApp";
 			};
 			name = Debug;
 		};
@@ -595,7 +595,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MnemonicKit.app/MnemonicKit";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MnemonicKitExampleApp.app/MnemonicKitExampleApp";
 			};
 			name = Release;
 		};

--- a/Sources/App/Info.plist
+++ b/Sources/App/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>MnemonicKitExampleApp</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Preparation to make MnemonicKit a static library and drop the self-referencing pod in Podfile. 